### PR TITLE
Updated mod_syslog.erl to work with older versions of Erlang

### DIFF
--- a/src/mod_syslog.erl
+++ b/src/mod_syslog.erl
@@ -19,7 +19,7 @@
 
 start(Host, Opts) ->
 	application:start(syslog),
-	{syslog, SyslogOptions} = lists:keyfind(syslog, 1, Opts),
+	{value, {syslog, SyslogOptions}} = lists:keysearch(syslog, 1, Opts),
 	ok = syslog:settings(element(1, SyslogOptions), element(2, SyslogOptions), element(3, SyslogOptions)),
 	?SYSLOG_INFO(ejabberd, "starting mod_syslog", []),
 	lists:foreach(fun(Elem)->
@@ -39,7 +39,7 @@ start(Host, Opts) ->
 				?SYSLOG_INFO(ejabberd, "mod_syslog enabling presence module", []);
 			_ -> ok
 		end
-	end, element(2, lists:keyfind(modules, 1, Opts))),
+	end, element(2, element(2, lists:keysearch(modules, 1, Opts)))),
 	
 	ok.
 
@@ -57,7 +57,7 @@ presence_update(User, Server, Resource, Status) ->
 
 register_connection(_SID, JID, Info) ->
 	%%dict:fetch(ip, Info)
-	IP = element(1,element(2,lists:keyfind(ip, 1, Info))),
+	IP = element(1,element(2,element(2,lists:keysearch(ip, 1, Info)))),
 	?SYSLOG_INFO(ejabberd, "~s open connection from ~B.~B.~B.~B", [
 	    jlib:jid_to_string(JID), element(1, IP), element(2, IP), element(3, IP), element(4, IP)]),
 	ok.


### PR DESCRIPTION
This version uses the older lists:keysearch/3 function instead of the newer lists:keyfind/3
function that replaces and deprecates lists:keysearch/3.  CentOS 5.4 uses Erlang 5.6.5
which does not yet support lists:keyfind/3 - maybe other older operating systems would
find themselves in the same boat.

I expect this version would work on newer versions of Erlang, but since it is using the deprecated lists:keysearch/3 function, people using newer versions may not wish to use this version.
